### PR TITLE
Fix Mark and SecMark Attribute Parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "conntrack"
-version = "0.1.0"
-authors = [ "Matt Bolt <mbolt35@gmail.com" ]
+version = "0.1.1"
+authors = ["Matt Bolt <mbolt35@gmail.com>"]
 repository = "https://github.com/rusty-bolt/conntrack-rs"
 description = "Netfilter Conntrack"
 categories = ["network-programming"]

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -1,3 +1,7 @@
+//! # Attributes
+//! This module contains neli compatible attributes used to read and decode
+//! conntrack subsystem responses.
+
 use neli::{
     attr::AttrHandle,
     consts::genl::NlAttrType,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,3 +1,6 @@
+//! # Connection
+//! This module contains the general API for the conntrack library.
+
 use neli::{
     consts::{nl::*, socket::*},
     genl::Genlmsghdr,

--- a/src/decoders.rs
+++ b/src/decoders.rs
@@ -1,3 +1,7 @@
+//! # Decoders
+//! This module contains decoder traits and implementations capable of extracting
+//! conntrack table data from neli attributes.
+
 use std::net::IpAddr;
 use std::net::Ipv4Addr;
 use std::net::Ipv6Addr;

--- a/src/decoders.rs
+++ b/src/decoders.rs
@@ -147,6 +147,9 @@ impl<'a> AttrDecoder<'a, ConntrackAttr, Flow> for Flow {
                 ConntrackAttr::CtaTimeout => {
                     flow.timeout = Some(Duration::from_secs((u32::decode(attr)?) as u64));
                 }
+                ConntrackAttr::CtaMark => {
+                    flow.mark = Some(u32::decode(attr)?);
+                }
                 ConntrackAttr::CtaSeqAdjOrig => {
                     let seq_adj_orig_attr = attr.get_attr_handle::<SeqAdjAttr>()?;
 
@@ -166,7 +169,7 @@ impl<'a> AttrDecoder<'a, ConntrackAttr, Flow> for Flow {
                     flow.sec_ctx = Some(SecCtx::decode(sec_ctx_attr)?);
                 }
                 ConntrackAttr::CtaSecMark => {
-                    flow.mark = Some(u32::decode(attr)?);
+                    flow.sec_mark = Some(u32::decode(attr)?);
                 }
                 ConntrackAttr::CtaMarkMask => {
                     flow.mark_mask = Some(u32::decode(attr)?);

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,7 @@
+//! # Error
+//! This module contains all the potential error types that can come from
+//! the `conntrack` library.
+
 use std::fmt::Debug;
 
 /// Error consolidates and propagates all underlying error types.

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,3 +1,6 @@
+//! # Message
+//! This module contains neli compatible subsystem messages.
+
 use neli::neli_enum;
 
 #[inline]

--- a/src/model.rs
+++ b/src/model.rs
@@ -46,6 +46,7 @@ pub struct Flow {
     pub seq_adj_orig: Option<SeqAdj>,
     pub seq_adj_repl: Option<SeqAdj>,
     pub sec_ctx: Option<SecCtx>,
+    pub sec_mark: Option<u32>,
     pub exp: Option<Exp>,
 }
 #[neli_enum(serialized_type = "u8")]

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,3 +1,6 @@
+//! # Model
+//! This module contains rust model structs for the decoded conntrack data.
+
 use bitflags::bitflags;
 use chrono::prelude::*;
 use neli::neli_enum;

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,3 +1,6 @@
+//! # Result
+//! This module contains the result alias and a module reimport for the error types.
+
 pub use crate::error::Error;
 
 /// Result is an alias for `core::result::Result<T, conntrack::error::Error>`


### PR DESCRIPTION
Issue: `SecMark` was being applied to `mark` on the `Flow` model incorrectly. 
Fix: 
* Added a `sec_mark` field to `Flow` and correctly set on `SecMark` attribute
* Added handling for `Mark` attribute and correctly set `mark` on `Flow`
