### PR TITLE
Add support for event based conntrack

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,14 @@
-[target.x86_64-unknown-linux-gnu]
-runner = 'sudo -E'
+[target.armv7-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"
+
+[target.armv7-unknown-linux-musleabihf]
+linker = "./arm-linux-musleabihf-cross/bin/arm-linux-musleabihf-gcc"
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[env]
+CC_armv7_unknown_linux_gnueabihf = "arm-linux-gnueabihf-gcc"
+CXX_armv7_unknown_linux_gnueabihf = "arm-linux-gnueabihf-g++"
+AR_armv7_unknown_linux_gnueabihf = "arm-linux-gnueabihf-ar"
+CC_armv7_unknown_linux_musleabihf = "qemu-arm-static"
+CXX_armv7_unknown_linux_musleabihf = "qemu-arm-static"
+AR_armv7_unknown_linux_musleabihf = "qemu-arm-static"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,7 @@ env_logger = "0.11.8"
 [[example]]
 name = "conntrack-dump"
 path = "examples/conntrack_dump.rs"
+
+[[example]]
+name = "conntrack-events"
+path = "examples/conntrack_events.rs"

--- a/examples/conntrack_events.rs
+++ b/examples/conntrack_events.rs
@@ -1,26 +1,56 @@
 use conntrack::*;
 use env_logger::Env;
+use std::env;
 
-/// This example enables logging, connects to netfilter via socket, dumps
-/// conntrack tables, and iterates and logs each flow within the table.
+/// This example demonstrates real-time conntrack event monitoring.
+/// It's equivalent to running `conntrack -E` from the command line.
+/// 
+/// Usage: conntrack-events [-d|--debug]
 fn main() -> Result<()> {
+    let args: Vec<String> = env::args().collect();
+    let debug = args.iter().any(|arg| arg == "-d" || arg == "--debug");
+    
+    let log_level = if debug { "debug" } else { "info" };
     let env = Env::default()
-        .filter_or("RUST_LOG", "info")
+        .filter_or("RUST_LOG", log_level)
         .write_style_or("RUST_LOG_STYLE", "always");
 
     env_logger::init_from_env(env);
 
-    // Create the Conntrack table via netfilter socket syscall
+    log::info!("Starting conntrack event monitoring...");
+    log::info!("This is equivalent to running 'conntrack -E'");
+    if debug {
+        log::info!("Debug mode enabled");
+    }
+    log::info!("Press Ctrl+C to stop");
+
+    // Create the Conntrack instance
     let mut ct = Conntrack::connect()?;
 
-    // Dump conntrack table as a Vec<Flow>
-    let flows = ct.dump()?;
+    // Monitor all events (NEW, UPDATE, DESTROY)
+    let event_mask = EventMask::all();
+    let receiver = ct.monitor_events(event_mask, None, debug)?;
 
-    for (i, flow) in flows.iter().enumerate() {
-        log::info!("[{}] Connection:", i + 1);
+    let mut event_count = 0;
+
+    // Process events as they come in
+    for event in receiver {
+        event_count += 1;
         
+        match event.event_type {
+            ConntrackEventType::New => {
+                log::info!("[{}] NEW connection:", event_count);
+            }
+            ConntrackEventType::Update => {
+                log::info!("[{}] UPDATE connection:", event_count);
+            }
+            ConntrackEventType::Destroy => {
+                log::info!("[{}] DESTROY connection:", event_count);
+            }
+        }
+
         // Print connection details
-        if let Some(origin) = &flow.origin {
+        if let Some(origin) = &event.flow.origin {
             if let Some(src) = origin.src {
                 if let Some(dst) = origin.dst {
                     if let Some(proto) = &origin.proto {
@@ -85,7 +115,7 @@ fn main() -> Result<()> {
         }
 
         // Print reply connection details if available
-        if let Some(reply) = &flow.reply {
+        if let Some(reply) = &event.flow.reply {
             if let Some(src) = reply.src {
                 if let Some(dst) = reply.dst {
                     if let Some(proto) = &reply.proto {
@@ -133,7 +163,7 @@ fn main() -> Result<()> {
         }
 
         // Print TCP state information
-        if let Some(proto_info) = &flow.proto_info {
+        if let Some(proto_info) = &event.flow.proto_info {
             if let Some(tcp_info) = &proto_info.tcp {
                 if let Some(state) = &tcp_info.state {
                     log::info!("  TCP State: {:?}", state);
@@ -141,11 +171,11 @@ fn main() -> Result<()> {
             }
         }
 
-        // Print status information
-        if let Some(status) = &flow.status {
+        // Print additional flow information
+        if let Some(status) = &event.flow.status {
             log::info!("  Status: {:?}", status);
             
-            // Check for UNREPLIED status
+            // Check for UNREPLIED status (indicates NEW event)
             if status.contains(&"StatusSeenReply".to_string()) {
                 log::info!("  [REPLIED]");
             } else {
@@ -157,20 +187,20 @@ fn main() -> Result<()> {
                 log::info!("  [ASSURED]");
             }
         }
-
-        if let Some(timeout) = flow.timeout {
+        
+        if let Some(timeout) = event.flow.timeout {
             log::info!("  Timeout: {:?}", timeout);
         }
 
         // Print byte and packet counters if available
-        if let Some(counter_origin) = &flow.counter_origin {
+        if let Some(counter_origin) = &event.flow.counter_origin {
             if let Some(packets) = counter_origin.packets {
                 if let Some(bytes) = counter_origin.bytes {
                     log::info!("  Origin: {} packets, {} bytes", packets, bytes);
                 }
             }
         }
-        if let Some(counter_reply) = &flow.counter_reply {
+        if let Some(counter_reply) = &event.flow.counter_reply {
             if let Some(packets) = counter_reply.packets {
                 if let Some(bytes) = counter_reply.bytes {
                     log::info!("  Reply: {} packets, {} bytes", packets, bytes);
@@ -178,6 +208,13 @@ fn main() -> Result<()> {
             }
         }
 
+        log::info!("  Timestamp: {}", event.timestamp.format("%Y-%m-%d %H:%M:%S%.3f"));
+        
+        // Show raw flow data in debug mode
+        if debug {
+            log::debug!("  Raw flow data: {:#?}", event.flow);
+        }
+        
         log::info!("");
     }
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -9,6 +9,9 @@ use neli::{
     types::{Buffer, GenlBuffer},
     utils::Groups,
 };
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
 
 use crate::attributes::*;
 use crate::decoders::*;
@@ -62,5 +65,218 @@ impl Conntrack {
         }
 
         Ok(flows)
+    }
+
+    /// Start monitoring conntrack events in real-time.
+    /// This method creates a background thread that continuously listens for events
+    /// and sends them through a channel.
+    /// 
+    /// # Arguments
+    /// * `event_mask` - Which events to monitor (NEW, UPDATE, DESTROY)
+    /// * `buffer_size` - Optional netlink socket buffer size in bytes
+    /// * `debug` - Enable debug output
+    /// 
+    /// # Returns
+    /// A receiver that will receive `ConntrackEvent` instances as they occur.
+    /// 
+    /// # Example
+    /// ```rust
+    /// use conntrack::*;
+    /// 
+    /// let mut ct = Conntrack::connect()?;
+    /// let event_mask = EventMask::all();
+    /// let receiver = ct.monitor_events(event_mask, None, false)?;
+    /// 
+    /// // Process events as they come in
+    /// for event in receiver {
+    ///     println!("Event: {:?}", event);
+    /// }
+    /// ```
+    pub fn monitor_events(
+        &mut self,
+        event_mask: EventMask,
+        buffer_size: Option<usize>,
+        debug: bool,
+    ) -> Result<mpsc::Receiver<ConntrackEvent>> {
+        let (tx, rx) = mpsc::channel();
+        
+        if debug {
+            log::info!("Setting up event monitoring with mask: {:?}", event_mask);
+            log::info!("Netlink flags: 0x{:x}", event_mask.to_netlink_flags());
+        }
+        
+        // Create a new socket for event monitoring
+        // The key issue was here - we need to join the multicast groups, not pass flags to connect
+        let mut event_socket = NlSocketHandle::connect(NlFamily::Netfilter, None, Groups::empty())?;
+        
+        // Join the multicast groups for the events we want to monitor
+        // Using the correct neli API - we need to create Groups objects
+        if event_mask.new {
+            let groups = Groups::new_groups(&[libc::NFNLGRP_CONNTRACK_NEW as u32]);
+            event_socket.add_mcast_membership(groups)?;
+            if debug {
+                log::info!("Joined NEW events group: {}", libc::NFNLGRP_CONNTRACK_NEW);
+            }
+        }
+        if event_mask.update {
+            let groups = Groups::new_groups(&[libc::NFNLGRP_CONNTRACK_UPDATE as u32]);
+            event_socket.add_mcast_membership(groups)?;
+            if debug {
+                log::info!("Joined UPDATE events group: {}", libc::NFNLGRP_CONNTRACK_UPDATE);
+            }
+        }
+        if event_mask.destroy {
+            let groups = Groups::new_groups(&[libc::NFNLGRP_CONNTRACK_DESTROY as u32]);
+            event_socket.add_mcast_membership(groups)?;
+            if debug {
+                log::info!("Joined DESTROY events group: {}", libc::NFNLGRP_CONNTRACK_DESTROY);
+            }
+        }
+        
+        if debug {
+            log::info!("Successfully joined multicast groups");
+        }
+
+        // Set buffer size if specified
+        if let Some(_size) = buffer_size {
+            // Note: neli doesn't expose socket buffer size setting directly
+            // This would need to be implemented using raw socket operations
+            log::warn!("Buffer size setting not yet implemented in neli");
+        }
+
+        // Spawn background thread for event monitoring
+        thread::spawn(move || {
+            if debug {
+                log::info!("Event monitoring thread started");
+            }
+            
+            loop {
+                match Self::receive_event(&mut event_socket, debug) {
+                    Ok(event) => {
+                        if debug {
+                            log::debug!("Received event: {:?}", event.event_type);
+                        }
+                        if let Err(_) = tx.send(event) {
+                            // Receiver was dropped, exit the thread
+                            if debug {
+                                log::info!("Event monitoring thread exiting - receiver dropped");
+                            }
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        log::error!("Error receiving event: {}", e);
+                        // Continue trying to receive events
+                        thread::sleep(Duration::from_millis(100));
+                    }
+                }
+            }
+        });
+
+        Ok(rx)
+    }
+
+    /// Receive a single event from the netlink socket.
+    /// This is a blocking operation.
+    fn receive_event(socket: &mut NlSocketHandle, debug: bool) -> Result<ConntrackEvent> {
+        let (recv_iter, _) = socket
+            .recv::<CtNetlinkMessage, Genlmsghdr<u8, ConntrackAttr>>()?;
+
+        for result in recv_iter {
+            let result: Nlmsghdr<CtNetlinkMessage, Genlmsghdr<u8, ConntrackAttr>> = result?;
+            
+            if debug {
+                log::debug!("Received netlink message type: {:?}", result.nl_type());
+            }
+            
+            if let NlPayload::Payload(message) = result.nl_payload() {
+                let handle = message.attrs().get_attr_handle();
+                let flow = Flow::decode(handle)?;
+                
+                if debug {
+                    log::debug!("Received Netlink message type: {:?}", result.nl_type());
+                    log::debug!("Flow ID: {:?}", flow.id);
+                    log::debug!("Flow status: {:?}", flow.status);
+                }
+                
+                // Determine event type based on message type and status flags
+                let event_type = match result.nl_type() {
+                    CtNetlinkMessage::ConntrackNew => {
+                        // For NEW messages, check if this is actually an UPDATE based on status
+                        if let Some(status) = &flow.status {
+                            if status.contains(&"StatusSeenReply".to_string()) {
+                                ConntrackEventType::Update
+                            } else {
+                                ConntrackEventType::New
+                            }
+                        } else {
+                            ConntrackEventType::New
+                        }
+                    },
+                    CtNetlinkMessage::ConntrackUpdate => ConntrackEventType::Update,
+                    CtNetlinkMessage::ConntrackDestroy => ConntrackEventType::Destroy,
+                    _ => {
+                        if debug {
+                            log::debug!("Skipping unknown message type: {:?}", result.nl_type());
+                        }
+                        // Skip unknown message types
+                        continue;
+                    }
+                };
+
+                if debug {
+                    log::debug!("Decoded event type: {:?}", event_type);
+                }
+
+                return Ok(ConntrackEvent {
+                    event_type,
+                    flow,
+                    timestamp: chrono::Utc::now(),
+                });
+            }
+        }
+
+        Err(Error::NoData)
+    }
+
+    /// Monitor events with a callback function.
+    /// This is a convenience method that handles the channel internally.
+    /// 
+    /// # Arguments
+    /// * `event_mask` - Which events to monitor
+    /// * `buffer_size` - Optional netlink socket buffer size
+    /// * `debug` - Enable debug output
+    /// * `callback` - Function to call for each event
+    /// 
+    /// # Example
+    /// ```rust
+    /// use conntrack::*;
+    /// 
+    /// let mut ct = Conntrack::connect()?;
+    /// let event_mask = EventMask::new_only();
+    /// 
+    /// ct.monitor_events_with_callback(event_mask, None, false, |event| {
+    ///     println!("New connection: {:?}", event.flow);
+    /// })?;
+    /// ```
+    pub fn monitor_events_with_callback<F>(
+        &mut self,
+        event_mask: EventMask,
+        buffer_size: Option<usize>,
+        debug: bool,
+        mut callback: F,
+    ) -> Result<()>
+    where
+        F: FnMut(ConntrackEvent) + Send + 'static,
+    {
+        let receiver = self.monitor_events(event_mask, buffer_size, debug)?;
+        
+        thread::spawn(move || {
+            for event in receiver {
+                callback(event);
+            }
+        });
+
+        Ok(())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,9 @@ pub enum Error {
 
     #[error(transparent)]
     NlBuilder(#[from] neli::nl::NlmsghdrBuilderError),
+
+    #[error("No data received")]
+    NoData,
 }
 
 impl<T: Debug, P: Debug> From<neli::err::RouterError<T, P>> for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@
 pub use crate::connection::*;
 pub use crate::error::*;
 pub use crate::result::*;
+pub use crate::model::*;
 
 pub mod attributes;
 pub mod decoders;

--- a/src/message.rs
+++ b/src/message.rs
@@ -8,6 +8,11 @@ const fn subsys_message(subsys: CtNetlinkSubsys, msg: CtMessage) -> u16 {
     ((subsys as u16) << 8) | (msg as u16)
 }
 
+#[inline]
+const fn subsys_event_message(subsys: CtNetlinkSubsys, msg: CtEventMessage) -> u16 {
+    ((subsys as u16) << 8) | (msg as u16)
+}
+
 #[repr(u8)]
 #[allow(unused)]
 pub enum CtNetlinkSubsys {
@@ -28,9 +33,19 @@ pub enum CtMessage {
     CtGetUnconfirmed = 7u8,
 }
 
+#[repr(u8)]
+pub enum CtEventMessage {
+    CtNew = 0u8,
+    CtUpdate = 1u8,
+    CtDestroy = 2u8,
+}
+
 #[neli_enum(serialized_type = "u16")]
 pub enum CtNetlinkMessage {
     Conntrack = subsys_message(CtNetlinkSubsys::CtNetlink, CtMessage::CtGet),
+    ConntrackNew = subsys_event_message(CtNetlinkSubsys::CtNetlink, CtEventMessage::CtNew),
+    ConntrackUpdate = subsys_event_message(CtNetlinkSubsys::CtNetlink, CtEventMessage::CtUpdate),
+    ConntrackDestroy = subsys_event_message(CtNetlinkSubsys::CtNetlink, CtEventMessage::CtDestroy),
 }
 
 impl neli::consts::nl::NlType for CtNetlinkMessage {}

--- a/src/model.rs
+++ b/src/model.rs
@@ -308,3 +308,86 @@ bitflags! {
         const StatusOffload = 1 << 14;
     }
 }
+
+/// Event types for conntrack monitoring
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ConntrackEventType {
+    /// New connection established
+    New,
+    /// Existing connection updated
+    Update,
+    /// Connection destroyed/expired
+    Destroy,
+}
+
+/// Event mask for filtering which events to monitor
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct EventMask {
+    pub new: bool,
+    pub update: bool,
+    pub destroy: bool,
+}
+
+impl EventMask {
+    /// Create an event mask that monitors all events
+    pub fn all() -> Self {
+        Self {
+            new: true,
+            update: true,
+            destroy: true,
+        }
+    }
+
+    /// Create an event mask that monitors only new connections
+    pub fn new_only() -> Self {
+        Self {
+            new: true,
+            update: false,
+            destroy: false,
+        }
+    }
+
+    /// Create an event mask that monitors only updates
+    pub fn update_only() -> Self {
+        Self {
+            new: false,
+            update: true,
+            destroy: false,
+        }
+    }
+
+    /// Create an event mask that monitors only destroyed connections
+    pub fn destroy_only() -> Self {
+        Self {
+            new: false,
+            update: false,
+            destroy: true,
+        }
+    }
+
+    /// Convert to netlink event flags
+    pub fn to_netlink_flags(&self) -> u32 {
+        let mut flags = 0u32;
+        if self.new {
+            flags |= libc::NFNLGRP_CONNTRACK_NEW as u32;
+        }
+        if self.update {
+            flags |= libc::NFNLGRP_CONNTRACK_UPDATE as u32;
+        }
+        if self.destroy {
+            flags |= libc::NFNLGRP_CONNTRACK_DESTROY as u32;
+        }
+        flags
+    }
+}
+
+/// A conntrack event containing the event type and flow information
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ConntrackEvent {
+    /// The type of event (NEW, UPDATE, DESTROY)
+    pub event_type: ConntrackEventType,
+    /// The flow information
+    pub flow: Flow,
+    /// Timestamp when the event was received
+    pub timestamp: DateTime<Utc>,
+}


### PR DESCRIPTION
Add event based conntrack usage.
Tested on x64, aarch64, armv7l linux platform.
Example output:
```
[2025-09-08T11:18:20Z INFO  conntrack_events] [12] NEW connection:
[2025-09-08T11:18:20Z INFO  conntrack_events]   100.126.208.24:62417 -> 192.168.51.1:80 (proto: 6)
[2025-09-08T11:18:20Z INFO  conntrack_events]   [REPLY] 192.168.51.1:80 -> 100.126.208.24:62417
[2025-09-08T11:18:20Z INFO  conntrack_events]   TCP State: SynSent
[2025-09-08T11:18:20Z INFO  conntrack_events]   Status: ["StatusConfirmed", "StatusSrcNATDone", "StatusDstNATDone"]
[2025-09-08T11:18:20Z INFO  conntrack_events]   [UNREPLIED]
[2025-09-08T11:18:20Z INFO  conntrack_events]   Timeout: 120s
[2025-09-08T11:18:20Z INFO  conntrack_events]   Timestamp: 2025-09-08 11:18:20.157
[2025-09-08T11:18:20Z INFO  conntrack_events]
[2025-09-08T11:18:20Z INFO  conntrack_events] [13] UPDATE connection:
[2025-09-08T11:18:20Z INFO  conntrack_events]   100.126.208.24:62417 -> 192.168.51.1:80 (proto: 6)
[2025-09-08T11:18:20Z INFO  conntrack_events]   [REPLY] 192.168.51.1:80 -> 100.126.208.24:62417
[2025-09-08T11:18:20Z INFO  conntrack_events]   TCP State: SynRecv
[2025-09-08T11:18:20Z INFO  conntrack_events]   Status: ["StatusSeenReply", "StatusConfirmed", "StatusSrcNATDone", "StatusDstNATDone"]
[2025-09-08T11:18:20Z INFO  conntrack_events]   [REPLIED]
[2025-09-08T11:18:20Z INFO  conntrack_events]   Timeout: 60s
[2025-09-08T11:18:20Z INFO  conntrack_events]   Timestamp: 2025-09-08 11:18:20.157
```