### PR TITLE
Remove Exclusive Reference Requirement

### DIFF
--- a/examples/conntrack_dump.rs
+++ b/examples/conntrack_dump.rs
@@ -11,7 +11,7 @@ fn main() -> Result<()> {
     env_logger::init_from_env(env);
 
     // Create the Conntrack table via netfilter socket syscall
-    let mut ct = Conntrack::connect()?;
+    let ct = Conntrack::connect()?;
 
     // Dump conntrack table as a Vec<Flow>
     let flows = ct.dump()?;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -32,7 +32,7 @@ impl Conntrack {
 
     /// The dump call will list all connection tracking for the `Conntrack` table as a
     /// `Vec<Flow>` instances.
-    pub fn dump(&mut self) -> Result<Vec<Flow>> {
+    pub fn dump(&self) -> Result<Vec<Flow>> {
         let genlhdr = GenlmsghdrBuilder::default()
             .cmd(0u8)
             .version(libc::NFNETLINK_V0 as u8)


### PR DESCRIPTION
`Conntrack::dump()` does not need a `&mut self`